### PR TITLE
Take PHP7 support for amqp_envelope.h

### DIFF
--- a/amqp_envelope.h
+++ b/amqp_envelope.h
@@ -20,6 +20,13 @@
   | - Jonathan Tansavatdi                                                |
   +----------------------------------------------------------------------+
 */
+
+#if PHP_MAJOR_VERSION >= 7
+        #include "php7_support.h"
+#else
+        #include "php5_support.h"
+#endif
+
 extern zend_class_entry *amqp_envelope_class_entry;
 
 void convert_amqp_envelope_to_zval(amqp_envelope_t *amqp_envelope, zval *envelope TSRMLS_DC);


### PR DESCRIPTION
This allows `TSRMLS_DC` to be resolved correctly when building on PHP8.0